### PR TITLE
Add a command to clean up old application versions

### DIFF
--- a/lib/deploy/checks.rb
+++ b/lib/deploy/checks.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 require 'deploy/utility'
 
 module Deploy
@@ -7,9 +9,16 @@ module Deploy
     def check_setup
       (shout('docker not installed'); exit(1)) unless command?('docker')
       (shout('eb command not installed'); exit(1)) unless command?('eb')
-      (shout('elasticbeanstalk not configured for this project. run "eb init".'); exit(1)) unless File.exist?('.elasticbeanstalk')
+      (shout('elasticbeanstalk not configured for this project. run "eb init".'); exit(1)) unless File.readable?('.elasticbeanstalk/config.yml')
       (shout('AWS credentials not configured.'); exit(1)) unless ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['AWS_REGION']
       (shout('ENV DOCKER_REPO not set'); exit(1)) unless ENV['DOCKER_REPO']
+
+      @config = YAML.load_file('.elasticbeanstalk/config.yml')
+      @application_name = @config['global']['application_name']
+    end
+
+    def application_name
+      @application_name || (raise 'Call #check_setup first')
     end
 
     def check_rollback_version(version, environment)

--- a/lib/deploy/output.rb
+++ b/lib/deploy/output.rb
@@ -44,6 +44,10 @@ module Deploy
       colorize(35, message)
     end
 
+    def blue(message)
+      colorize(34, message)
+    end
+
     def colorize(color_code, message)
       "\e[#{color_code}m#{message}\e[0m"
     end

--- a/lib/deploy/runner.rb
+++ b/lib/deploy/runner.rb
@@ -61,6 +61,12 @@ module Deploy
       end
     end
 
+    desc 'clean_old_versions', 'Remove all unused versions older than two days except the most recent 50'
+    def clean_old_versions
+      check_setup
+      delete_old_versions
+    end
+
     method_option :environment, aliases: '-e', desc: 'Environment', required: true
     desc 'show version', 'show environment version'
     def version

--- a/lib/deploy/runner.rb
+++ b/lib/deploy/runner.rb
@@ -47,12 +47,12 @@ module Deploy
       create_deploy_zip_file(*files)
     end
 
-    desc 'send test notification', 'send test notification'
+    desc 'test_slack', 'send test notification'
     def test_slack
       notifier('', { color: 'good', title: 'This is a test notification from eb-docker-deploy.' })
     end
 
-    desc 'list versions', 'list all application versions'
+    desc 'versions', 'list all application versions'
     def versions
       check_setup
 
@@ -68,14 +68,14 @@ module Deploy
     end
 
     method_option :environment, aliases: '-e', desc: 'Environment', required: true
-    desc 'show version', 'show environment version'
+    desc 'version', 'show environment version'
     def version
       check_setup
 
       shout current_version_for_environment(options[:environment])
     end
 
-    desc 'setup config', 'setup config'
+    desc 'setup', 'setup config'
     def setup
       (shout('AWS creds already configured in ~/.bashrc'); exit(1)) if ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['AWS_REGION']
 

--- a/lib/deploy/version.rb
+++ b/lib/deploy/version.rb
@@ -1,3 +1,3 @@
 module Deploy
-  VERSION = "1.4.6"
+  VERSION = "1.5.0"
 end

--- a/lib/deploy/versions.rb
+++ b/lib/deploy/versions.rb
@@ -5,7 +5,7 @@ module Deploy
     include Deploy::Utility
 
     def eb
-      Aws::ElasticBeanstalk::Client.new
+      @eb ||= Aws::ElasticBeanstalk::Client.new
     end
 
     def version_exists?(version)
@@ -13,12 +13,37 @@ module Deploy
     end
 
     def current_version_for_environment(environment)
-      eb.describe_environments(environment_names: [environment]).environments.first.version_label
+      eb.describe_environments(application_name: application_name, environment_names: [environment]).environments.first.version_label
     end
 
     def application_versions_array
-      @array ||= eb.describe_application_versions.application_versions.reverse.map(&:version_label)
+      @array ||= eb.describe_application_versions(application_name: application_name).application_versions.reverse.map(&:version_label)
     end
 
+    def delete_old_versions
+      versions = eb.describe_application_versions(application_name: application_name).application_versions.sort_by(&:date_updated)
+      environments = eb.describe_environments(application_name: application_name).environments
+      env_versions = environments.map(&:version_label)
+      versions.reject!{|v|
+        env = environments.detect{|e| e.version_label == v.version_label}
+        if env
+          shout "Not deleting version #{v.version_label} in use by #{env.environment_name}"
+          true
+        elsif v.date_updated >= Time.now - (86400 * 2)
+          shout "Not deleting version #{v.version_label} that is less than two days old"
+          true
+        else
+          false
+        end
+      }
+
+      versions.each_with_index do |v, idx|
+        if idx < versions.count - 50
+          say "Deleting old version #{red v.version_label} from #{pink v.date_updated}"
+        else
+          say "Keeping version #{blue v.version_label} from #{pink v.date_updated}"
+        end
+      end
+    end
   end
 end

--- a/lib/deploy/versions.rb
+++ b/lib/deploy/versions.rb
@@ -40,6 +40,7 @@ module Deploy
       versions.each_with_index do |v, idx|
         if idx < versions.count - 50
           say "Deleting old version #{red v.version_label} from #{pink v.date_updated}"
+          eb.delete_application_version(application_name: application_name, version_label: v.version_label, delete_source_bundle: true)
         else
           say "Keeping version #{blue v.version_label} from #{pink v.date_updated}"
         end


### PR DESCRIPTION
This avoids the following error, if run before deploying:

> ERROR: You cannot have more than 500 Application Versions. Either remove some Application Versions or request a limit increase.
